### PR TITLE
2 3 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ for var in ['x', 'y']:
     bdd.add_var(var)
 xy = bdd.add_expr('x & y')
 u = bdd.quantify(xy, {'x', 'y'}, forall=False)
-assert u == bdd.True, u
+assert u == bdd.true, u
 ```
 
 

--- a/dd/_parser.py
+++ b/dd/_parser.py
@@ -174,8 +174,8 @@ def add_ast(t, bdd):
 
     @type t: `Terminal` or `Operator` of `astutils`
     @type bdd: object with:
-      - `bdd.False`
-      - `bdd.True`
+      - `bdd.false`
+      - `bdd.true`
       - `bdd.var`
       - `bdd.apply`
       - `bdd.quantify`
@@ -194,7 +194,7 @@ def add_ast(t, bdd):
             operands = [add_ast(x, bdd) for x in t.operands]
             return bdd.apply(t.operator, *operands)
     elif t.type == 'bool':
-        u = bdd.False if t.value.lower() == 'false' else bdd.True
+        u = bdd.false if t.value.lower() == 'false' else bdd.true
         return u
     elif t.type == 'var':
         return bdd.var(t.value)

--- a/dd/autoref.py
+++ b/dd/autoref.py
@@ -145,12 +145,12 @@ class BDD(object):
 
     @property
     def False(self):
-        u = self._bdd.False
+        u = self._bdd.false
         return self._wrap(u)
 
     @property
     def True(self):
-        u = self._bdd.True
+        u = self._bdd.true
         return self._wrap(u)
 
 

--- a/dd/autoref.py
+++ b/dd/autoref.py
@@ -144,12 +144,12 @@ class BDD(object):
         self._bdd.assert_consistent()
 
     @property
-    def False(self):
+    def false(self):
         u = self._bdd.false
         return self._wrap(u)
 
     @property
-    def True(self):
+    def true(self):
         u = self._bdd.true
         return self._wrap(u)
 

--- a/dd/bdd.py
+++ b/dd/bdd.py
@@ -46,6 +46,10 @@ except ImportError:
 import logging
 import pickle
 import sys
+try:
+    sys.maxint
+except AttributeError:
+    sys.maxint = sys.maxsize
 from dd import _parser
 # inline:
 # import networkx

--- a/dd/bdd.py
+++ b/dd/bdd.py
@@ -104,9 +104,7 @@ class BDD(object):
         self.ordering = dict()
         self.vars = self.ordering
         self._level_to_var = dict()
-        ordering = dict(ordering)
-        if ordering is None:
-            ordering = dict()
+        ordering = dict(ordering or {})
         _assert_valid_ordering(ordering)
         for var, level in ordering.iteritems():
             self.add_var(var, level)

--- a/dd/bdd.py
+++ b/dd/bdd.py
@@ -55,6 +55,12 @@ from dd import _parser
 # import networkx
 # import pydot
 
+if not 'iteritems' in dict.__dict__: # python3 compat
+    class _dict(dict):
+        def iteritems(self):
+            return self.items()
+    dict = _dict
+
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +99,7 @@ class BDD(object):
         self.ordering = dict()
         self.vars = self.ordering
         self._level_to_var = dict()
+        ordering = dict(ordering)
         if ordering is None:
             ordering = dict()
         _assert_valid_ordering(ordering)
@@ -1026,7 +1033,7 @@ class BDD(object):
         @type dvars: `dict`
         """
         r = 1
-        for var, val in dvars.iteritems():
+        for var, val in dict(dvars).iteritems():
             i = self.ordering.get(var, var)
             u = self.find_or_add(i, -1, 1)
             if not val:
@@ -1169,7 +1176,7 @@ def rename(u, bdd, dvars):
     k = next(iter(dvars))
     if k in ordering:
         dvars = {ordering[k]: ordering[v]
-                 for k, v in dvars.iteritems()}
+                 for k, v in dict(dvars).iteritems()}
     _assert_valid_rename(u, bdd, dvars)
     umap = dict()
     return _rename(u, bdd, dvars, umap)
@@ -1259,14 +1266,14 @@ def image(trans, source, rename, qvars, bdd, forall=False):
     qvars = bdd._map_to_level(qvars)
     rename = {
         bdd.ordering.get(k, k): bdd.ordering.get(v, v)
-        for k, v in rename.iteritems()}
+        for k, v in dict(rename).iteritems()}
     # init
     cache = dict()
     rename_u = rename
     rename_v = None
     # no overlap and neighbors
     _assert_no_overlap(rename)
-    for v, vp in rename.iteritems():
+    for v, vp in dict(rename).iteritems():
         _assert_adjacent(v, vp, bdd)
     # unpriming maps to qvars or outside support of conjunction
     s = bdd.support(trans, as_levels=True)
@@ -1299,7 +1306,7 @@ def preimage(trans, target, rename, qvars, bdd, forall=False):
     qvars = bdd._map_to_level(qvars)
     rename = {
         bdd.ordering.get(k, k): bdd.ordering.get(v, v)
-        for k, v in rename.iteritems()}
+        for k, v in dict(rename).iteritems()}
     # init
     cache = dict()
     rename_u = None
@@ -1474,7 +1481,7 @@ def reorder_to_pairs(bdd, pairs):
     """
     m = 0
     levels = bdd._levels()
-    for x, y in pairs.iteritems():
+    for x, y in dict(pairs).iteritems():
         jx = bdd.ordering[x]
         jy = bdd.ordering[y]
         k = abs(jx - jy)

--- a/dd/bdd.py
+++ b/dd/bdd.py
@@ -38,7 +38,11 @@ Henrik R. Andersen
     The IT University of Copenhagen
 """
 from collections import Mapping
-from itertools import tee, izip
+from itertools import tee
+try:  # python3 compat
+    from itertools import izip
+except ImportError:
+    izip = zip
 import logging
 import pickle
 import sys

--- a/dd/bdd.py
+++ b/dd/bdd.py
@@ -61,6 +61,11 @@ if not 'iteritems' in dict.__dict__: # python3 compat
             return self.items()
     dict = _dict
 
+try: # python3 compat
+    xrange(1)
+except NameError:
+    xrange = range
+
 
 logger = logging.getLogger(__name__)
 

--- a/dd/bdd.py
+++ b/dd/bdd.py
@@ -1086,11 +1086,11 @@ class BDD(object):
 
     # !!! DO NOT MOVE up, because arg defaults affected
     @property
-    def False(self):
+    def false(self):
         return -1
 
     @property
-    def True(self):
+    def true(self):
         return 1
 
 

--- a/dd/buddy.pyx
+++ b/dd/buddy.pyx
@@ -116,7 +116,7 @@ cdef class BDD(object):
             var, self.var_to_index)
         j = self.var_to_index[var]
         r = buddy.bdd_ithvar(j)
-        assert r != self.False.node, 'failed'
+        assert r != self.false.node, 'failed'
         buddy.bdd_intaddvarblock(j, j, 0)
         return Function(r)
 

--- a/dd/cudd.pyx
+++ b/dd/cudd.pyx
@@ -724,8 +724,8 @@ cdef class Function(object):
     In Python, use as:
     ```
     bdd = BDD()
-    u = bdd.True
-    v = bdd.False
+    u = bdd.true
+    v = bdd.false
     w = u | ~ v
 
     In Cython, use as:
@@ -854,7 +854,7 @@ cdef class Function(object):
 cpdef _test_incref():
     bdd = BDD()
     cdef Function f
-    f = bdd.True
+    f = bdd.true
     i = f.ref
     bdd.incref(f.node)
     j = f.ref
@@ -866,7 +866,7 @@ cpdef _test_incref():
 cpdef _test_decref():
     bdd = BDD()
     cdef Function f
-    f = bdd.True
+    f = bdd.true
     i = f.ref
     assert i == 2, i
     bdd.incref(f.node)

--- a/dd/dddmp.py
+++ b/dd/dddmp.py
@@ -29,6 +29,11 @@ import ply.yacc
 import astutils
 from dd.bdd import BDD
 
+if not 'iteritems' in dict.__dict__: # python3 compat
+    class _dict(dict):
+        def iteritems(self):
+            return self.items()
+    dict = _dict
 
 logger = logging.getLogger(__name__)
 TABMODULE = 'dd.dddmp_parsetab'
@@ -59,7 +64,7 @@ class Lexer(object):
         'rootnames': 'ROOTNAMES',
         'nodes': 'NODES',
         'end': 'END'}
-    reserved = {'.{k}'.format(k=k): v for k, v in reserved.iteritems()}
+    reserved = {'.{k}'.format(k=k): v for k, v in dict(reserved).iteritems()}
     misc = ['MINUS', 'DOT', 'NAME', 'NUMBER']
     # token rules
     t_MINUS = r'-'
@@ -68,7 +73,7 @@ class Lexer(object):
     t_ignore = ' \t'
 
     def __init__(self, debug=False):
-        self.tokens = self.misc + self.reserved.values()
+        self.tokens = self.misc + list(self.reserved.values())
         self.build(debug=debug)
 
     def t_KEYWORD(self, t):
@@ -422,15 +427,15 @@ def load(fname):
     parser = Parser()
     bdd_succ, n_vars, ordering, roots = parser.parse(fname)
     # reindex to ensure no blanks
-    perm = {k: var for var, k in ordering.iteritems()}
+    perm = {k: var for var, k in dict(ordering).iteritems()}
     perm = {i: perm[k] for i, k in enumerate(sorted(perm))}
-    new_ordering = {var: k for k, var in perm.iteritems()}
+    new_ordering = {var: k for k, var in dict(perm).iteritems()}
     old2new = {ordering[var]: new_ordering[var] for var in ordering}
     # convert
     bdd = BDD(new_ordering)
     umap = {-1: -1, 1: 1}
     for j in xrange(len(new_ordering) - 1, -1, -1):
-        for u, (k, v, w) in bdd_succ.iteritems():
+        for u, (k, v, w) in dict(bdd_succ).iteritems():
             # terminal ?
             if v is None:
                 assert w is None, w

--- a/download.py
+++ b/download.py
@@ -77,7 +77,7 @@ def extensions():
             sources=['dd/buddy' + pyx],
             libraries=['bdd']))
     if pyx == '.pyx':
-        for k, v in extensions.iteritems():
+        for k, v in extensions.items():
             extensions[k] = cythonize(v)[0]
     return extensions
 

--- a/download.py
+++ b/download.py
@@ -93,7 +93,7 @@ def fetch(url, sha256, fname=None):
         fname = url.split('/')[-1]
     with open(fname, 'wb') as f:
         f.write(u.read())
-    with open(fname, 'r') as f:
+    with open(fname, 'rb') as f:
         s = f.read()
         h = hashlib.sha256(s)
         x = h.hexdigest()

--- a/download.py
+++ b/download.py
@@ -4,7 +4,11 @@ import os
 import subprocess
 import sys
 import tarfile
-import urllib2
+try:
+    import urllib2
+except ImportError:
+    import urllib.request, urllib.error, urllib.parse
+    urllib2 = urllib.request
 try:
     from Cython.Build import cythonize
     pyx = '.pyx'

--- a/tests/cudd_test.py
+++ b/tests/cudd_test.py
@@ -8,8 +8,8 @@ logging.getLogger('astutils').setLevel('ERROR')
 
 def test_true_false():
     bdd = cudd.BDD()
-    true = bdd.True
-    false = bdd.False
+    true = bdd.true
+    false = bdd.false
     assert false != true
     assert false == ~true
     assert false == false & true
@@ -42,10 +42,10 @@ def test_var_cofactor():
     x = bdd.var('x')
     values = dict(x=False)
     u = bdd.cofactor(x, values)
-    assert u == bdd.False, u
+    assert u == bdd.false, u
     values = dict(x=True)
     u = bdd.cofactor(x, values)
-    assert u == bdd.True, u
+    assert u == bdd.true, u
     del x, u
 
 
@@ -77,12 +77,12 @@ def test_richcmp():
 def test_len():
     bdd = cudd.BDD()
     assert len(bdd) == 0, len(bdd)
-    u = bdd.True
+    u = bdd.true
     assert len(bdd) == 1, len(bdd)
     del u
     assert len(bdd) == 0, len(bdd)
-    u = bdd.True
-    v = bdd.False
+    u = bdd.true
+    v = bdd.false
     assert len(bdd) == 1, len(bdd)
     bdd.add_var('x')
     x = bdd.var('x')
@@ -102,14 +102,14 @@ def test_len():
 
 def test_contains():
     bdd = cudd.BDD()
-    true = bdd.True
+    true = bdd.true
     assert true in bdd
     bdd.add_var('x')
     x = bdd.var('x')
     assert x in bdd
     # undefined `__contains__`
     other_bdd = cudd.BDD()
-    other_true = other_bdd.True
+    other_true = other_bdd.true
     with assert_raises(AssertionError):
         other_true in bdd
     del x, true, other_true
@@ -150,35 +150,35 @@ def test_cofactor():
     # x & y
     u = bdd.apply('and', x, y)
     r = bdd.cofactor(u, dict(x=False, y=False))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     r = bdd.cofactor(u, dict(x=True, y=False))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     r = bdd.cofactor(u, dict(x=False, y=True))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     r = bdd.cofactor(u, dict(x=True, y=True))
-    assert r == bdd.True, r
+    assert r == bdd.true, r
     # x & !y
     not_y = bdd.apply('not', y)
     u = bdd.apply('and', x, not_y)
     r = bdd.cofactor(u, dict(x=False, y=False))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     r = bdd.cofactor(u, dict(x=True, y=False))
-    assert r == bdd.True, r
+    assert r == bdd.true, r
     r = bdd.cofactor(u, dict(x=False, y=True))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     r = bdd.cofactor(u, dict(x=True, y=True))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     # !x | y
     not_x = bdd.apply('not', x)
     u = bdd.apply('or', not_x, y)
     r = bdd.cofactor(u, dict(x=False, y=False))
-    assert r == bdd.True, r
+    assert r == bdd.true, r
     r = bdd.cofactor(u, dict(x=True, y=False))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     r = bdd.cofactor(u, dict(x=False, y=True))
-    assert r == bdd.True, r
+    assert r == bdd.true, r
     r = bdd.cofactor(u, dict(x=True, y=True))
-    assert r == bdd.True, r
+    assert r == bdd.true, r
     del x, not_x, y, not_y, u, r
 
 
@@ -192,10 +192,10 @@ def test_apply():
     # x | !x = 1
     not_x = bdd.apply('not', x)
     true = bdd.apply('or', x, not_x)
-    assert true == bdd.True, true
+    assert true == bdd.true, true
     # x & !x = 0
     false = bdd.apply('and', x, not_x)
-    assert false == bdd.False, false
+    assert false == bdd.false, false
     # x & y = ! (!x | !y)
     u = bdd.apply('and', x, y)
     not_y = bdd.apply('not', y)
@@ -205,13 +205,13 @@ def test_apply():
     # xor
     u = bdd.apply('xor', x, y)
     r = bdd.cofactor(u, dict(x=False, y=False))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     r = bdd.cofactor(u, dict(x=True, y=False))
-    assert r == bdd.True, r
+    assert r == bdd.true, r
     r = bdd.cofactor(u, dict(x=False, y=True))
-    assert r == bdd.True, r
+    assert r == bdd.true, r
     r = bdd.cofactor(u, dict(x=True, y=True))
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     # (z | !y) & x = (z & x) | (!y & x)
     u = bdd.apply('or', z, not_y)
     u = bdd.apply('and', u, x)
@@ -242,10 +242,10 @@ def test_quantify():
     x = bdd.var('x')
     # ? x. x = 1
     r = bdd.quantify(x, ['x'], forall=False)
-    assert r == bdd.True, r
+    assert r == bdd.true, r
     # ! x. x = 0
     r = bdd.quantify(x, ['x'], forall=True)
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     # ? y. x = x
     r = bdd.quantify(x, ['y'], forall=False)
     assert r == x, (r, x)
@@ -260,7 +260,7 @@ def test_quantify():
     assert r != x, (r, x)
     # ! x. x & y = 0
     r = bdd.quantify(u, ['x'], forall=True)
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     # ! x. !x | y = y
     not_x = bdd.apply('not', x)
     u = bdd.apply('or', not_x, y)
@@ -320,7 +320,7 @@ def test_add_expr():
     assert u == y, (str(u), str(y))
     # ! x. x | !x = 1
     u = bdd.add_expr('! x. !x | x')
-    assert u == bdd.True, u
+    assert u == bdd.true, u
     del x, y, z, u, u_
 
 
@@ -364,7 +364,7 @@ def test_and_exists():
     # ? x. x & !x = 0
     not_x = bdd.apply('not', x)
     r = cudd.and_exists(x, not_x, qvars, bdd)
-    assert r == bdd.False
+    assert r == bdd.false
     del x, not_x, y, r
 
 
@@ -377,7 +377,7 @@ def test_or_forall():
     not_y = bdd.add_expr('!y')
     qvars = ['x', 'y']
     r = cudd.or_forall(x, not_y, qvars, bdd)
-    assert r == bdd.False, r
+    assert r == bdd.false, r
     del x, not_y, r
 
 
@@ -468,7 +468,7 @@ def test_copy_bdd_same_indices():
     w = other.add_expr(s)
     assert w == u1, (w, u1)
     # different nodes
-    u3 = cudd.copy_bdd(other.True, other, bdd)
+    u3 = cudd.copy_bdd(other.true, other, bdd)
     assert u3 != u2, (u3, u2)
     # same bdd
     with assert_raises(AssertionError):
@@ -523,7 +523,7 @@ def test_copy_bdd_different_order():
     u1 = cudd.copy_bdd(u0, bdd, other)
     u2 = cudd.copy_bdd(u1, other, bdd)
     assert u0 == u2, (u0, u2)
-    u3 = cudd.copy_bdd(other.False, other, bdd)
+    u3 = cudd.copy_bdd(other.false, other, bdd)
     assert u3 != u2, (u3, u2)
     # verify
     w = other.add_expr(s)
@@ -538,16 +538,16 @@ def test_function():
     x = bdd.var('x')
     assert not x.negated
     low = x.low
-    assert low == bdd.False, low
+    assert low == bdd.false, low
     high = x.high
-    assert high == bdd.True, high
+    assert high == bdd.true, high
     # ! x
     not_x = ~x
     assert not_x.negated
     low = not_x.low
-    assert low == bdd.False, low
+    assert low == bdd.false, low
     high = not_x.high
-    assert high == bdd.True, high
+    assert high == bdd.true, high
     del x, not_x, low, high
 
 


### PR DESCRIPTION
I've monkey-patched everything that is needed for this thing to run in python3 as well. I don't know whether izip, xrange and iteritems from 2.7 are really neccessary and if not using them has a large impact on performance. 

The code would be nicer if we just replaced every occurence with their counterparts. But I guess this works fine.