### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 
 python:
   - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ language: python
 python:
   - 2.7
 
+addons:
+  apt:
+    packages:
+    - graphviz
+
 install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y graphviz
   - pip install --upgrade pip setuptools
   - pip install -r requirements.txt
   - python setup.py install --fetch --cudd


### PR DESCRIPTION
I've added the common python versions so that we see the errors immediately and removed graphviz manual installation, now using the suggested process:
http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade#How-do-I-install-APT-sources-and-packages%3F